### PR TITLE
Tighten up typing

### DIFF
--- a/pycfa/cfanalyser.py
+++ b/pycfa/cfanalyser.py
@@ -18,7 +18,7 @@ Analyse control flow for a piece of Python code.
 
 import ast
 import contextlib
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, Generator, List, Tuple, Union
 
 from pycfa.cfanalysis import CFAnalysis
 from pycfa.cfgraph import CFGraph
@@ -89,7 +89,7 @@ class CFAnalyser:
         self._graph.add_node(node, edges=edges)
         return node
 
-    def _ast_node(self, statement: ast.AST, **edges: CFNode):
+    def _ast_node(self, statement: ast.AST, **edges: CFNode) -> CFNode:
         """
         Create a new node wrapping an AST node, with given edges to existing nodes.
         """
@@ -97,7 +97,7 @@ class CFAnalyser:
         self._graph.add_node(node, edges=edges)
         return node
 
-    def _dummy_node(self):
+    def _dummy_node(self) -> CFNode:
         """
         Create a new dummy node, which will eventually be removed.
         """
@@ -108,7 +108,7 @@ class CFAnalyser:
     # Context management
 
     @contextlib.contextmanager
-    def _updated_context(self, **updates: CFNode):
+    def _updated_context(self, **updates: CFNode) -> Generator[None, None, None]:
         """
         Temporarily update the context dictionary with the given values.
         """
@@ -127,7 +127,7 @@ class CFAnalyser:
                     del context[label]
 
     @property
-    def _raise(self):
+    def _raise(self) -> CFNode:
         return self._context[_RAISE]
 
     # General analysis helpers.
@@ -163,7 +163,9 @@ class CFAnalyser:
         self._graph.collapse_node(dummy_node, loop_node)
         return loop_node
 
-    def _analyse_statements(self, statements: List[ast.stmt], *, next) -> CFNode:
+    def _analyse_statements(
+        self, statements: List[ast.stmt], *, next: CFNode
+    ) -> CFNode:
         """
         Analyse a sequence of statements.
         """
@@ -237,35 +239,35 @@ class CFAnalyser:
         """
         return expr.value
 
-    def _getvalue_expr_NameConstant(self, expr: ast.Constant) -> Any:
+    def _getvalue_expr_NameConstant(self, expr: ast.NameConstant) -> Any:
         """
         Value of a NameConstant expression.
         """
         return expr.value
 
-    def _getvalue_expr_Num(self, expr: ast.Constant) -> Any:
+    def _getvalue_expr_Num(self, expr: ast.Num) -> Any:
         """
         Value of a Num expression.
         """
         return expr.n
 
-    def _getvalue_expr_Str(self, expr: ast.Constant) -> str:
+    def _getvalue_expr_Str(self, expr: ast.Str) -> Any:
         """
         Value of a Str expression.
         """
         return expr.s
 
-    def _getvalue_expr_Bytes(self, expr: ast.Constant) -> bytes:
+    def _getvalue_expr_Bytes(self, expr: ast.Bytes) -> Any:
         """
         Value of a Bytes expression.
         """
         return expr.s
 
-    def _getvalue_expr_Ellipsis(self, expr: ast.Constant) -> Any:
+    def _getvalue_expr_Ellipsis(self, expr: ast.Ellipsis) -> Any:
         """
         Value of an Ellipsis expression.
         """
-        return ...
+        return Ellipsis
 
     # Statement analyzers for particular AST node types.
 

--- a/pycfa/cfanalysis.py
+++ b/pycfa/cfanalysis.py
@@ -29,7 +29,7 @@ class CFAnalysis:
     """
 
     #: The first node of the module, function or class.
-    entry_node: Optional[CFNode]
+    entry_node: CFNode
 
     #: Dummy node representing the exit point of a module, function or class.
     #: For functions, this node is reached on a plain "return" or on the implicit
@@ -38,6 +38,7 @@ class CFAnalysis:
     leave_node: Optional[CFNode]
 
     #: Dummy node representing an uncaught exception in a module, function or class.
+    #: This attribute may be missing, but will not be None.
     raise_node: Optional[CFNode]
 
     #: Dummy node representing an explicit return-with-value from a function.
@@ -57,12 +58,9 @@ class CFAnalysis:
     ) -> None:
         self._graph = graph
         self.entry_node = entry_node
-        if raise_node is not None:
-            self.raise_node = raise_node
-        if leave_node is not None:
-            self.leave_node = leave_node
-        if return_node is not None:
-            self.return_node = return_node
+        self.raise_node = raise_node
+        self.leave_node = leave_node
+        self.return_node = return_node
 
     # Graph inspection methods.
 

--- a/pycfa/cfgraph.py
+++ b/pycfa/cfgraph.py
@@ -32,13 +32,13 @@ Parallel edges (with different labels) and self-loops are permitted.
 Nodes can be any hashable object.
 """
 
-from typing import Dict, Generic, Mapping, Optional, Set, Tuple, TypeVar
+from typing import Container, Dict, Mapping, Optional, Set, Tuple, TypeVar
 
 #: Type of nodes. For now, require only that nodes are hashable.
 NodeType = TypeVar("NodeType")
 
 
-class CFGraph(Generic[NodeType]):
+class CFGraph(Container[NodeType]):
     """
     The directed graph underlying the control flow graph.
     """
@@ -64,7 +64,7 @@ class CFGraph(Generic[NodeType]):
         node: NodeType,
         *,
         edges: Optional[Mapping[str, NodeType]] = None,
-    ):
+    ) -> None:
         """
         Add a new node, along with edges to existing nodes to the graph.
 
@@ -185,7 +185,7 @@ class CFGraph(Generic[NodeType]):
 
     # Support for membership testing
 
-    def __contains__(self, node: NodeType) -> bool:
+    def __contains__(self, node: object) -> bool:
         """
         Determine whether a given node is contained in the graph.
         """

--- a/pycfa/test/test_cfgraph.py
+++ b/pycfa/test/test_cfgraph.py
@@ -23,7 +23,7 @@ from pycfa.cfgraph import CFGraph
 
 
 class TestCFGraph(unittest.TestCase):
-    def test_add_node_with_edges(self):
+    def test_add_node_with_edges(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(23, edges={})
         self.assertIn(23, graph)
@@ -31,49 +31,42 @@ class TestCFGraph(unittest.TestCase):
         graph.add_node(47, edges={"next": 23})
         self.assertIn(47, graph)
 
-    def test_add_node_edges_parameter_is_optional(self):
+    def test_add_node_edges_parameter_is_optional(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(23)
         self.assertIn(23, graph)
 
-    def test_add_node_edges_parameter_is_keyword_only(self):
-        # The edges parameter must be passed by name.
-        graph: CFGraph[int] = CFGraph()
-        with self.assertRaises(TypeError):
-            graph.add_node(23, {})
-        self.assertNotIn(23, graph)
-
-    def test_add_node_twice(self):
+    def test_add_node_twice(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(23)
         with self.assertRaises(ValueError):
             graph.add_node(23)
 
-    def test_add_node_with_self_edge(self):
+    def test_add_node_with_self_edge(self) -> None:
         graph: CFGraph[int] = CFGraph()
         with self.assertRaises(ValueError):
             graph.add_node(23, edges={"self": 23})
 
-    def test_add_node_edge_to_nonexistent_node(self):
+    def test_add_node_edge_to_nonexistent_node(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(23)
         with self.assertRaises(ValueError):
             graph.add_node(47, edges={"next": 48})
 
-    def test_remove_node(self):
+    def test_remove_node(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(47)
         self.assertIn(47, graph)
         graph.remove_node(47)
         self.assertNotIn(47, graph)
 
-    def test_remove_nonexistent_node(self):
+    def test_remove_nonexistent_node(self) -> None:
         graph: CFGraph[int] = CFGraph()
         with self.assertRaises(ValueError):
             graph.remove_node(47)
         self.assertNotIn(47, graph)
 
-    def test_remove_node_with_forward_edges(self):
+    def test_remove_node_with_forward_edges(self) -> None:
         graph: CFGraph[int] = CFGraph()
 
         graph.add_node(24)
@@ -82,7 +75,7 @@ class TestCFGraph(unittest.TestCase):
             graph.remove_node(23)
         self.assertIn(23, graph)
 
-    def test_remove_node_with_back_edges(self):
+    def test_remove_node_with_back_edges(self) -> None:
         graph: CFGraph[int] = CFGraph()
 
         graph.add_node(24)
@@ -91,7 +84,7 @@ class TestCFGraph(unittest.TestCase):
             graph.remove_node(24)
         self.assertIn(24, graph)
 
-    def test_collapse_node(self):
+    def test_collapse_node(self) -> None:
         graph: CFGraph[int] = CFGraph()
 
         graph.add_node(3)
@@ -115,7 +108,7 @@ class TestCFGraph(unittest.TestCase):
         self.assertEqual(graph.edge(0, "next"), 3)
         self.assertEqual(graph.edges_to(3), {(0, "next"), (1, "step")})
 
-    def test_collapse_node_with_forward_edges(self):
+    def test_collapse_node_with_forward_edges(self) -> None:
         graph: CFGraph[int] = CFGraph()
 
         graph.add_node(3)
@@ -125,7 +118,7 @@ class TestCFGraph(unittest.TestCase):
         with self.assertRaises(ValueError):
             graph.collapse_node(1, 3)
 
-    def test_collapse_node_with_bad_node(self):
+    def test_collapse_node_with_bad_node(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(3)
 
@@ -135,7 +128,7 @@ class TestCFGraph(unittest.TestCase):
         with self.assertRaises(ValueError):
             graph.collapse_node(3, 1)
 
-    def test_collapse_with_identical_nodes(self):
+    def test_collapse_with_identical_nodes(self) -> None:
         graph: CFGraph[int] = CFGraph()
         graph.add_node(3)
 


### PR DESCRIPTION
This PR:

- adds some missing type information
- fixes (either weakens or strengthens, as appropriate) some other type declarations
- changes the API of `CFAnalysis`: for nodes that may or may not exist (like `return_node`), those nodes are stored as either `None` or the node value, rather than raising `AttributeError` on access if they don't exist.